### PR TITLE
Use NuGet package instead of VSIX.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,15 @@ In order to build this project you need:
 
 * Windows 10
 * Visual Studio 2017 or 2019
-* PSPDFKit for Windows.vsix Visual Studio Extension ([get your trial here](https://pspdfkit.com/try/))
+* PSPDFKit for Windows NuGet package. ([get your trial here](https://pspdfkit.com/try/))
 * [Visual Studio Tools for Xamarin](https://visualstudio.microsoft.com/xamarin/)
 * Getting familiar with [Xamarin.Forms UWP project setup](https://docs.microsoft.com/en-us/xamarin/xamarin-forms/platform/windows/installation/).
 
 ### Running the sample project
 
-Open `XamarinPDF.sln` using Visual Studio add your license key as a String value in the `App.xaml` files listed below:
+First place the PSPDFKit for Windows NuGet package file in the directory `\Xamarin-UWP\nuget\`. You can find this in the SDK zip file.
+
+Open `XamarinPDF.sln` using Visual Studio and add your license key as a String value in the `App.xaml` files listed below:
 
 * [XamarinPDF/XamarinPDF.UWP/App.xaml](XamarinPDF/XamarinPDF.UWP/App.xaml)
 
@@ -34,15 +36,11 @@ Replace `LICENSE_KEY_GOES_HERE` with your provided license from the PSPDFKit cus
 
 ```xaml
 <ResourceDictionary>
-    <x:String x:Key="PSPDFKitLicense"> LICENSE_KEY_GOES_HERE </x:String>
+    <x:String x:Key="PSPDFKitLicense">LICENSE_KEY_GOES_HERE</x:String>
 </ResourceDictionary>
 ```
 
-Now you can build and run the sample project.
-
-**Note**:
-> You do not need `PSPDFKitLicense` to be present in both `App.xaml` in your actual application, in this provided project we are just demonstrating that the license initialization can be done either from Xamarin.Forms or the actual UWP project; you can choose just one of the `App.xaml` files to host the `PSPDFKitLicense `.
-
+You can now build and run the project.
 
 ## Using PSPDFKit for Windows in your Xamarin.Forms UWP project
 

--- a/XamarinPDF/XamarinPDF.UWP/XamarinPDF.UWP.csproj
+++ b/XamarinPDF/XamarinPDF.UWP/XamarinPDF.UWP.csproj
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" 
-  xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <AppxWinMdCacheEnabled>false</AppxWinMdCacheEnabled>
@@ -239,6 +238,9 @@
     <PackageReference Include="Microsoft.Toolkit.Uwp.UI.Controls">
       <Version>4.0.0</Version>
     </PackageReference>
+    <PackageReference Include="PSPDFKitUWP">
+      <Version>2.*</Version>
+    </PackageReference>
     <PackageReference Include="Xamarin.Forms" Version="3.1.0.697729" />
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.1.7" />
   </ItemGroup>
@@ -247,14 +249,6 @@
       <Project>{FBB48106-6072-4FF0-AB74-93AFC1A4DD39}</Project>
       <Name>XamarinPDF</Name>
     </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
-    <SDKReference Include="Microsoft.VCLibs, Version=14.0">
-      <Name>Visual C++ 2015 Runtime for Universal Windows Platform Apps</Name>
-    </SDKReference>
-    <SDKReference Include="PSPDFKitSDK, Version=2.3.1">
-      <Name>PSPDFKit for UWP</Name>
-    </SDKReference>
   </ItemGroup>
   <ItemGroup>
     <Content Include="Assets\pdfs\default.pdf" />

--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+   <packageSources>
+       <add key="PSPDFKitSource" value=".\nuget\" />
+   </packageSources>
+</configuration>

--- a/nuget/Place PSPDFKit NuGet Package Here.txt
+++ b/nuget/Place PSPDFKit NuGet Package Here.txt
@@ -1,0 +1,1 @@
+Place the PSPDFKit for Windows NuGet package in this directory.


### PR DESCRIPTION
NuGet packages are the preferred way to integrate PSPDFKit for Windows.