### PR TITLE
Update PSPDFKit version to 2.11.1

### DIFF
--- a/XamarinPDF/XamarinPDF.UWP/App.xaml
+++ b/XamarinPDF/XamarinPDF.UWP/App.xaml
@@ -5,19 +5,19 @@
     xmlns:local="using:XamarinPDF.UWP"
     RequestedTheme="Light">
 
-	<Application.Resources>
-		<ResourceDictionary>
-			<ResourceDictionary.MergedDictionaries>
-				<ResourceDictionary Source="/Styles/_Colors.xaml" />
-				<ResourceDictionary Source="/Styles/_FontSizes.xaml" />
-				<ResourceDictionary Source="/Styles/_Thickness.xaml" />
-				<ResourceDictionary Source="/Styles/TextBlock.xaml" />
-				<ResourceDictionary Source="/Styles/Page.xaml" />
+    <Application.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="/Styles/_Colors.xaml" />
+                <ResourceDictionary Source="/Styles/_FontSizes.xaml" />
+                <ResourceDictionary Source="/Styles/_Thickness.xaml" />
+                <ResourceDictionary Source="/Styles/TextBlock.xaml" />
+                <ResourceDictionary Source="/Styles/Page.xaml" />
                 <ResourceDictionary>
-                    <x:String x:Key="PSPDFKitLicense">YOUR_LICENSE_KEY_GOES_HERE</x:String>
+                    <x:String x:Key="PSPDFKitLicense"></x:String>
                 </ResourceDictionary>
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
-	</Application.Resources>
+    </Application.Resources>
 
 </Application>

--- a/XamarinPDF/XamarinPDF.UWP/XamarinPDF.UWP.csproj
+++ b/XamarinPDF/XamarinPDF.UWP/XamarinPDF.UWP.csproj
@@ -239,7 +239,7 @@
       <Version>6.1.1</Version>
     </PackageReference>
     <PackageReference Include="PSPDFKitUWP">
-      <Version>2.10.0</Version>
+      <Version>2.11.1</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Forms" Version="4.8.0.1269" />
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.2.10" />


### PR DESCRIPTION
License key is not required for starting the example in trial mode anymore.